### PR TITLE
Add support for translating a single file

### DIFF
--- a/WorkshopAutoTranslation/WorkShopTranslationV2/Program.cs
+++ b/WorkshopAutoTranslation/WorkShopTranslationV2/Program.cs
@@ -26,7 +26,14 @@ namespace WorkShopTranslationV2
 				{ "traditional-chinese", "traditional-chinese" }
 			};
 
-            string filePath = args[0];
+			if (args.Length < 2)
+			{
+				Console.WriteLine("Please provide the path and language as command line arguments.\n" +
+					"Usage: dotnet run <path> <language> <model (optional)>");
+				return;
+			}
+
+			string path = args[0];
             string language = args[1];
 			string model = args.Length > 2 ? args[2] : "gpt-4o";
 
@@ -45,67 +52,77 @@ namespace WorkShopTranslationV2
                 credential,
                 new ChatCompletionsClientOptions());
 
-            ReadPrompts(filePath, model, language, supportedLanguages[language.ToLower()], client);
+			// Check if the input path is a markdown file
+            if (File.Exists(path) && Path.GetExtension(path).Equals(".md", StringComparison.OrdinalIgnoreCase))
+			{
+				TranslateFile(path, model, language, supportedLanguages[language.ToLower()], client);
+			}
+			// Otherwise, check if the input path is a directory
+			else if (Directory.Exists(path))
+			{
+				// Get a list of all markdown files in the folder and its subdirectories
+				string[] files = Directory.GetFiles(path, "*.md", SearchOption.AllDirectories);
+
+				foreach (string filePath in files)
+				{
+					TranslateFile(filePath, model, language, supportedLanguages[language.ToLower()], client);
+				}
+			}
+			else
+			{
+				Console.WriteLine("The path you entered is invalid. Please enter a valid file or directory path containing markdown files.");
+				return;
+			}
         }
 
-        public static void ReadPrompts(string folderPath, string model, string language, string languageFolder, ChatCompletionsClient client)
+        public static void TranslateFile(string filePath, string model, string language, string newFolder, ChatCompletionsClient client)
         {
-			// Get a list of all files in the folder
-			string[] files = Directory.GetFiles(folderPath);
-
-            foreach (string path in files)
-            {
-                Console.WriteLine($"Translating file: {path}");
-
-				string sourceStr = ReadFromFile(path);
-
-                try
-                {
-					// Translate the content of each file to the target language
-					var response = TranslateToLanguage(model, language, client, path);
-
-					// Handle the translation response here
-					// Create a translated file in the target language folder
-					string fileName = Path.GetFileName(path);
-					string contentFolder = Directory.GetParent(Directory.GetParent(folderPath).FullName).FullName;
-					string workshopFolder = Path.GetFileName(Path.GetDirectoryName(path));
-					string translatedFilePath = Path.Combine(contentFolder, languageFolder, workshopFolder, fileName);
-
-					// create the directory if it doesn't exist
-					string directoryPath = Path.GetDirectoryName(translatedFilePath);
-					if (directoryPath != null)
-					{
-						Directory.CreateDirectory(directoryPath);
-					}
-					else
-					{
-						throw new InvalidOperationException("The directory path is invalid.");
-					}
-
-					File.WriteAllText(translatedFilePath, response);
-
-					Console.WriteLine($"Success! Translated file path: {translatedFilePath}");
-                    Console.WriteLine();
+			Console.WriteLine($"Translating file: {filePath}");
+			
+			try
+			{
+				var translatedFilePath = filePath.Replace("english", newFolder);
+				
+				// Check if the translated file already exists
+				if (File.Exists(translatedFilePath))
+				{
+					Console.WriteLine($"A translated file already exists at: {translatedFilePath}, skipping translation.");
+					return;
 				}
-		        catch (Exception ex)
-                {
-                    Console.WriteLine($"An unexpected error occurred: {ex.Message}");
-				}
-            }
+
+				// Translate the contents of the file to the target language
+				var response = TranslateToLanguage(model, language, client, filePath);
+
+				// Create the directory if it doesn't exist
+				Directory.CreateDirectory(Path.GetDirectoryName(translatedFilePath)!);
+
+				// Write the translated content to the file
+				File.WriteAllText(translatedFilePath, response);
+
+				Console.WriteLine($"Success! Translated file path: {translatedFilePath}");
+				Console.WriteLine();
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"An unexpected error occurred: {ex.Message}");
+			}
         }
 
         public static string TranslateToLanguage(string model, string language, ChatCompletionsClient client, string filePath)
         {
-            string prompt = ReadFromFile(filePath);
+			string prompt = $"Translate the following file to {language}." +
+				$" Ensure that the translation does not alter any Hugo-specific syntax, front matter, or HTML tags." +
+				$" Only translate the plain text content. Do not translate code blocks, URLs, or any metadata." +
+				$" Maintain the structure and formatting of the original file.";
 
-            string message = @$"Translate the below to {language}: {prompt}; don't translate the header key title; don't translate the image html";
+			string fileContent = ReadFromFile(filePath);
 
             var requestOptions = new ChatCompletionsOptions()
             {
                 Messages =
                         {
-                            new ChatRequestSystemMessage(message),
-                            new ChatRequestUserMessage(prompt),
+                            new ChatRequestSystemMessage(prompt),
+                            new ChatRequestUserMessage(fileContent),
                         },
                 Model = model,
                 Temperature = 1.0f,
@@ -120,8 +137,8 @@ namespace WorkShopTranslationV2
         public static string ReadFromFile(string filePath)
         {
             // Read from a file
-            string sourceStr = File.ReadAllText(filePath);
-            return sourceStr;
+            string fileContents = File.ReadAllText(filePath);
+            return fileContents;
         }
     }
 }

--- a/WorkshopAutoTranslation/WorkShopTranslationV2/README.md
+++ b/WorkshopAutoTranslation/WorkShopTranslationV2/README.md
@@ -1,12 +1,12 @@
 # WorkShopTranslationV2 Tool
 
-This program is designed to translate a set of markdown files to a target language using [Github Models](https://github.com/marketplace/models). It reads the contents of each file in a specified directory, sends the content to an LLM, and saves the translated content to new files in a different directory.
+This program is designed to translate markdown file(s) to a target language using [Github Models](https://github.com/marketplace/models). It reads the contents of a file or folder, sends the content to an LLM, and saves the translated content to new files in a different directory depending on the target language.
 
 ## Features
 
-1. **Reading from Folder**: The script reads the content of each file in a given directory.
-2. **Translation using Github Models**: The script uses the Azure AI Inference SDK to translate the content by feeding it to a supported Github Models LLM.
-3. **Saving Translated Content**: Once translated, the script saves the translated content to new files in a different directory.
+1. **Reading from File/Folder**: The script reads the contents of markdown file(s) from an input path which can be either a file or folder.
+2. **Translation using Github Models**: The script uses the Azure AI Inference SDK to translate markdown file content by feeding it to a supported Github Models LLM.
+3. **Saving Translated Content**: Once translated, the script saves the translated content to new file(s) in a different directory.
 
 ## How to Use
 
@@ -32,7 +32,7 @@ Run the following command in terminal
 
 3. **Run the project**: Navigate to the `WorkShopTranslationV2` directory and run the following command:
 
-   `dotnet run <inputFolderPath> <targetLanguage> <model (optional)>`
+   `dotnet run <inputPath> <targetLanguage> <model (optional)>`
 
    ex. `dotnet run C:\Documents\workshops\content\english\csharp-basics french gpt-4o`
 


### PR DESCRIPTION
- Add support for translating a single file passed into the input path
- Update README.MD
- Add additional input validation
- Simplify translated file path logic
- Update logic to skip translating files if a translated file already exists
- Update logic to only translate markdown (.md) files