### PR TITLE
Increase MaxTokens from 1000 to 1500 in requestOptions

### DIFF
--- a/WorkshopAutoTranslation/WorkShopTranslationV2/Program.cs
+++ b/WorkshopAutoTranslation/WorkShopTranslationV2/Program.cs
@@ -126,7 +126,7 @@ namespace WorkShopTranslationV2
                         },
                 Model = model,
                 Temperature = 1.0f,
-                MaxTokens = 1000,
+                MaxTokens = 1500,
                 NucleusSamplingFactor = 1.0f
             };
 


### PR DESCRIPTION
The MaxTokens parameter in the requestOptions object has been increased from 1000 to 1500. This change allows the system to generate longer and more detailed responses by increasing the maximum number of tokens that can be used in the completion.